### PR TITLE
tspend: Support deterministic OP_RETURN

### DIFF
--- a/config.go
+++ b/config.go
@@ -22,7 +22,7 @@ import (
 var appName = "tspend"
 
 func version() string {
-	return "0.1.0"
+	return "0.1.1"
 }
 
 type chainNetwork string
@@ -113,6 +113,8 @@ type config struct {
 	CSV           string    `long:"csv" description:"Generate the tspend based on a csv file"`
 	Out           string    `long:"out" description:"Write resulting hex tspend to the specified file"`
 	Spew          bool      `long:"spew" description:"Spew the result tspend"`
+
+	DeterministicOpReturn bool `long:"deterministic" description:"Use a deterministic OP_RETURN data based on the input payloads"`
 
 	// The rest of the members of this struct are filled by loadConfig().
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/decred/dcrd/blockchain/standalone/v2 v2.1.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.3
 	github.com/decred/dcrd/chaincfg/v3 v3.1.1
+	github.com/decred/dcrd/crypto/blake256 v1.0.0
+	github.com/decred/dcrd/dcrjson/v4 v4.0.0
 	github.com/decred/dcrd/dcrutil/v4 v4.0.0
 	github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0
 	github.com/decred/dcrd/rpcclient/v7 v7.0.0


### PR DESCRIPTION
This adds a new argument '--deterministic' which forces generating a
deterministic OP_RETURN based on the payloads specified to the tool.

This reduces the chances of generating exactly duplicated tspends by
mistakenly calling the tool twice with the same set of inputs and
parameters (expiry, etc).

It also adds a log line to indicate the tspend was published or a
duplicated tspend was detected.